### PR TITLE
Added pyproject to easily install with pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "TIGTOG"
+version = "0.1.dev"
+dependencies = [
+  "pandas",
+  "matplotlib",
+  "scikit-learn~=1.2.1",
+  "joblib",
+  "biopython",
+]
+requires-python = ">=3.8"
+authors = [
+  {name = "Anh Ha", email = "anhdha@vt.edu "},
+]
+description = "TIGTOG is a command-line tool for assigning taxonomy to giant virus metagenome-assembled genomes (GVMAGs) using protein family trademarks."
+readme = "README.md"
+license = {file = "LICENSE"}
+
+[project.urls]
+Repository = "https://github.com/anhd-ha/TIGTOG"
+"Bug Tracker" = "https://github.com/anhd-ha/TIGTOG/issues"
+
+[project.scripts]
+tigtog = "tigtog:main"
+
+[tool.setuptools]
+py-modules = ["tigtog"]


### PR DESCRIPTION
Allow one to do 
```bash
pip install git+https://github.com/anhd-ha/TIGTOG.git
```
to install in a virtual environment.

Also allows to be called as a script from the virtual env :
```
tigtog -h
```

Note this was minimally tested but should be fully tested by the maintainers ;) 